### PR TITLE
Updated /home/git paths to /home/dokku to reflect changes in dokku.

### DIFF
--- a/recipes/apps.rb
+++ b/recipes/apps.rb
@@ -1,15 +1,15 @@
 node['dokku']['apps'].each do |app_name, config|
   delete = !!config['remove']
-  directory "/home/git/#{app_name}" do
-    owner 'git'
-    group 'git'
+  directory "/home/dokku/#{app_name}" do
+    owner 'dokku'
+    group 'dokku'
     action delete ? :delete : :create
   end
 
-  template "/home/git/#{app_name}/ENV" do
+  template "/home/dokku/#{app_name}/ENV" do
     source 'apps/ENV.erb'
-    owner  'git'
-    group  'git'
+    owner  'dokku'
+    group  'dokku'
     action :create
     variables(
       "env" => config['env'] || {}

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -47,10 +47,10 @@ end
 # Pull in aufs
 include_recipe "docker::aufs"
 
-# Create docker group with git and dokku as members
+# Create docker group with dokku as member
 group "docker" do
   append true
-  members ['git', 'dokku']
+  members ['dokku']
 end
 
 # Install docker
@@ -81,7 +81,7 @@ include_recipe 'dokku::apps'
 
 #set VHOST
 domain = node['dokku']['domain'] || node['fqdn']
-file '/home/git/VHOST' do
+file '/home/dokku/VHOST' do
   content domain
 end
 

--- a/recipes/ssh_keys.rb
+++ b/recipes/ssh_keys.rb
@@ -1,7 +1,7 @@
 node['dokku']['ssh_keys'].each do |user, key|
   # TODO make this into an LWRP
   bash "sshcommand_acl-add_key" do
-    cwd '/home/git'
+    cwd '/home/dokku'
     code <<-EOT
       echo '#{key}' | sshcommand acl-add dokku #{user}
     EOT

--- a/spec/apps_spec.rb
+++ b/spec/apps_spec.rb
@@ -19,18 +19,18 @@ describe 'dokku::apps' do
   end
   let(:chef_run) { chef_runner.converge described_recipe }
 
-  it 'should create the testapp directory under /home/git' do
-    expect(chef_run).to create_directory '/home/git/testapp'
+  it 'should create the testapp directory under /home/dokku' do
+    expect(chef_run).to create_directory '/home/dokku/testapp'
   end
 
   it 'should set the ownership of the testapp directory to git:git' do
-    app1_dir = chef_run.directory('/home/git/testapp')
-    expect(app1_dir.owner).to eq('git')
-    expect(app1_dir.group).to eq('git')
+    app1_dir = chef_run.directory('/home/dokku/testapp')
+    expect(app1_dir.owner).to eq('dokku')
+    expect(app1_dir.group).to eq('dokku')
   end
 
-  it 'should delete the testapp2 directory under /home/git' do
-    expect(chef_run).to delete_directory '/home/git/testapp2'
+  it 'should delete the testapp2 directory under /home/dokku' do
+    expect(chef_run).to delete_directory '/home/dokku/testapp2'
   end
 
   it 'should remove the app/testapp2 docker container' do
@@ -42,16 +42,16 @@ describe 'dokku::apps' do
   end
 
   it 'should not create an ENV file for testapp2' do
-    expect(chef_run).to_not create_file '/home/git/testapp2/ENV'
+    expect(chef_run).to_not create_file '/home/dokku/testapp2/ENV'
   end
 
   it 'should create the an ENV for testapp' do
-    expect(chef_run).to render_file("/home/git/testapp/ENV").with_content("export VAR1='a'\nexport VAR2='b'")
+    expect(chef_run).to render_file("/home/dokku/testapp/ENV").with_content("export VAR1='a'\nexport VAR2='b'")
   end
 
   it 'should set the ownership of the ENV file to git:git' do
-    env_file = chef_run.template('/home/git/testapp/ENV')
-    expect(env_file.owner).to eq('git')
-    expect(env_file.group).to eq('git')
+    env_file = chef_run.template('/home/dokku/testapp/ENV')
+    expect(env_file.owner).to eq('dokku')
+    expect(env_file.group).to eq('dokku')
   end
 end

--- a/spec/bootstrap_spec.rb
+++ b/spec/bootstrap_spec.rb
@@ -73,11 +73,11 @@ describe 'dokku::bootstrap' do
 
   it "creates the docker group" do
     expect(chef_run).to create_group('docker').with(
-      :members => ['git', 'dokku'], :append => true)
+      :members => ['dokku'], :append => true)
   end
 
   it "creates the VHOST file to the node's fqdn" do
-    expect(chef_run).to render_file("/home/git/VHOST").with_content(chef_run.node['fqdn'])
+    expect(chef_run).to render_file("/home/dokku/VHOST").with_content(chef_run.node['fqdn'])
   end
 
   context 'when the dokku domain is explicitly set' do
@@ -88,7 +88,7 @@ describe 'dokku::bootstrap' do
     end
 
     it "creates the VHOST file with the content 'foobar.com'" do
-      expect(chef_run).to render_file("/home/git/VHOST").with_content("foobar.com")
+      expect(chef_run).to render_file("/home/dokku/VHOST").with_content("foobar.com")
     end
   end
 

--- a/templates/default/plugins/nginx-vhosts/dokku.conf
+++ b/templates/default/plugins/nginx-vhosts/dokku.conf
@@ -1,1 +1,1 @@
-include /home/git/*/nginx.conf;
+include /home/dokku/*/nginx.conf;

--- a/templates/default/plugins/nginx-vhosts/nginx-reloader.conf
+++ b/templates/default/plugins/nginx-vhosts/nginx-reloader.conf
@@ -4,7 +4,7 @@ start on runlevel [2345]
 stop on runlevel [!2345]
 
 script
-  [[ -f /home/git/reload-nginx ]] && rm -rf /home/git/reload-nginx
-  echo | sudo -u git nc -l -U /home/git/reload-nginx && /etc/init.d/nginx reload
+  [[ -f /home/dokku/reload-nginx ]] && rm -rf /home/dokku/reload-nginx
+  echo | sudo -u dokku nc -l -U /home/dokku/reload-nginx && /etc/init.d/nginx reload
 end script
 respawn


### PR DESCRIPTION
Recent dokku commit (https://github.com/progrium/dokku/commit/b5c8dd7436d9a938c188b10be17e9f2fd9d35933) changed the dokku root path to: `/home/dokku/` instead of `/home/git/`. Thus, running the chef recipes failed.

This commit updates the paths correctly. All ChefSpec tests pass.
