### PR TITLE
Added boolean attribute flag for controlling use of docker::aufs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ src_url | The source url for the pluginhook .deb file | String | https://s3.amaz
 filename | The pluginhook .deb file name | String | pluginhook_0.1.0_amd64.deb
 checksum | The SHA-256 checksum for the pluginhook .deb file | String | 26a790070ee0c34fd4c53b24aabeb92778faed4004110c480c13b48608545fe5
 
+### Docker Attributes
+
+These attributes are under the `node['dokku']['docker']` namespace.
+
+Attribute | Description | Type | Default
+----------|-------------|------|--------
+use_aufs | Whether to install AUFS for docker | Boolean | true
+
 ## Recipes
 
 * `recipe[dokku]` - Noop. Will be used to include LWRPs in the future

--- a/attributes/bootstrap.rb
+++ b/attributes/bootstrap.rb
@@ -8,6 +8,8 @@ default['dokku']['pluginhook']['checksum'] = '26a790070ee0c34fd4c53b24aabeb92778
 default['dokku']['sshcommand']['filename'] = 'sshcommand'
 default['dokku']['sshcommand']['src_url'] = 'https://raw.github.com/progrium/sshcommand/master/sshcommand'
 
+default['dokku']['docker']['use_aufs'] = true
+
 # Nginx settings for dokku
 force_default['nginx']['default_site_enabled'] = false
 force_default['nginx']['server_names_hash_bucket_size'] = 64

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -45,7 +45,7 @@ dpkg_package pluginhook_name do
 end
 
 # Pull in aufs
-include_recipe "docker::aufs"
+include_recipe "docker::aufs" if node['dokku']['docker']['use_aufs']
 
 # Create docker group with dokku as member
 group "docker" do

--- a/spec/bootstrap_spec.rb
+++ b/spec/bootstrap_spec.rb
@@ -35,6 +35,13 @@ describe 'dokku::bootstrap' do
     end
   end
 
+  # Disabling docker::aufs with attribute flag
+  it "excludes the docker::aufs recipe when use_aufs is false" do
+    chef_run.node.set['dokku']['docker']['use_aufs'] = false
+    chef_run.converge described_recipe
+    expect(chef_run).to_not include_recipe 'docker::aufs'
+  end
+
   # sshcommand
   it "fetches sshcommand" do
     expect(chef_run).to create_remote_file("#{Chef::Config[:file_cache_path]}/sshcommand").with(


### PR DESCRIPTION
Docker 0.7 introduces standard linux support by no longer requiring the use of AUFS (which necessitated a patched Linux kernel). Thus, a boolean flag (set to true by default) is included as `node['dokku']['docker']['use_aufs']` and specifies whether or not the 'docker::aufs' recipe will be included during bootstrap. 

Setting this flag to false enables docker to be installed on more distributions and VPS providers. For example, linode does not support AUFS at the moment.
