### PR TITLE
Pinned versions of cookbook dependencies to prevent upstream breakage.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,9 @@ version          '0.2.0'
 
 supports 'ubuntu', '= 13.04'
 
-%w{apt git build-essential nginx docker user sudo}.each do |dep|
+%w{apt git build-essential user sudo}.each do |dep|
   depends dep
 end
+
+depends 'nginx', '~> 2.2.0'
+depends 'docker', '~> 0.24.2'


### PR DESCRIPTION
chef-docker released version 0.25 about a week ago which deprecates the use of `image_url` in `docker_image` LWRP. This broke the buildstack script. So I pinned chef-docker to 0.24 and put in the latest versions for all other cookbooks too.
