### PR TITLE
Add Travis CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # chef-dokku
+[![Build Status](https://secure.travis-ci.org/fgrehm/chef-dokku.png?branch=master)](http://travis-ci.org/fgrehm/chef-dokku)
 
 Manages a [dokku](https://github.com/progrium/dokku) installation, allowing
 configuration of application's [environment variables](https://github.com/progrium/dokku#environment-setup),


### PR DESCRIPTION
I figured that since you guys have set this to run on Travis CI, might as well pull in the build status badge to the README as that's one of the first things I look for when evaluating any cookbooks.
