### PR TITLE
Updated dependencies break deployment

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,5 +12,5 @@ supports 'ubuntu', '= 13.04'
   depends dep
 end
 
-depends 'nginx', '~> 2.2.0'
+depends 'nginx', '~> 2.4.4'
 depends 'docker', '>= 0.25.0'


### PR DESCRIPTION
The Docker dependency was updated in the Berkshelf file, but not in the metadata.rb, causing deployments to fail.

Updating the Docker dependency caused a version inconsistency between the nginx and all other cookbooks on the dependency on build-essential (~> 1.4.4 versus >= 0.0.0), since build-essential v2.0.0 is now available. This addresses both issues, with these changes I'm able to deploy using the current master (a7f76c688c6b0f4b49b85afb89af99037a58abe6) version of the Dokku cookbook again.
